### PR TITLE
fix $price declaration

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -84,6 +84,9 @@ abstract class ModuleCore
     /** @var bool Status */
     public $active = false;
 
+    /** @var float price */
+    public $price;
+
     /** @var bool Is the module certified by addons.prestashop.com */
     public $trusted = false;
 


### PR DESCRIPTION
Prevents error when loading modules page
PHP Notice:  Undefined property: stdClass::$price
